### PR TITLE
Fixed type hint typo

### DIFF
--- a/docs/unit03/documentation.rst
+++ b/docs/unit03/documentation.rst
@@ -222,7 +222,7 @@ script (only showing snippets below):
 
 .. code-block:: python3
 
-   def check_hemisphere(latitude: float, longitude: float) -> float:
+   def check_hemisphere(latitude: float, longitude: float) -> str:
 
 .. code-block:: python3
 


### PR DESCRIPTION
Type hint for return type of check_hemisphere was float when the function returns a string such as "Northern & Western."